### PR TITLE
Fixed `big` instance memory config

### DIFF
--- a/appService.json
+++ b/appService.json
@@ -28,7 +28,7 @@
             {
                 "name": "big",
                 "label": "Big",
-                "memory": 256,
+                "memory": 1024,
                 "description": "Big Memory Allocation"
             }
         ],


### PR DESCRIPTION
Hey, Angel. ACT had been using the "Big" instance but it seems it got stuck with 256mb memory which is the same as the small profile. I updated it to a value that makes sense for me, please review