### PR TITLE
Added docs and remove recursive

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ let resData = {
 
 // Optional
 let options = {
-  recursive: false,
   password: null, // If zip is password protected
 }
 

--- a/appService.js
+++ b/appService.js
@@ -9,9 +9,18 @@ svc.hooks.onSvcStop = (cause) => {
     svc.logger.info('ZIP Service is stopping.');
 }
 
+/**
+ * Zips an array of files and uploads the resulting zip file.
+ * @param {object} args - The arguments for the function.
+ * @param {object} args.params - The parameters for the function.
+ * @param {Array<{fileId: string, fileName: string}>} args.params.files - An array of file objects to zip.
+ * @param {string} args.params.fileName - The desired file name for the zip file. If not provided, a default name is used.
+ * @param {string} args.id - The ID of the request, used for sending events.
+ * @returns {object} - An object indicating success.
+ */
 svc.functions.zipFiles = ({ params, id }) => {
     let { files, fileName } = params;
-    fileName ??= id + '.zip'; // Default file name
+    fileName ??= `${id}.zip`; // Default file name
 
     zipFiles(files)
         .then(async (content) => {
@@ -30,6 +39,14 @@ svc.functions.zipFiles = ({ params, id }) => {
     return { ok: true };
 };
 
+/**
+ * Unzips a file and uploads the extracted files.
+ * @param {object} args - The arguments for the function.
+ * @param {object} args.params - The parameters for the function.
+ * @param {string} args.params.fileId - The ID of the zip file to unzip.
+ * @param {object} args.params.options - Options for unzipping, including password.
+ * @returns {object} - An object indicating success.
+ */
 svc.functions.unzipFile = ({ params, id }) => {
     let { fileId, options } = params;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zip-service",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zip-service",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@slingr/slingr-services": "^0.0.8",
         "adm-zip": "^0.5.14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zip-service",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Slingr Service to zip and unzip files",
   "main": "appService.js",
   "scripts": {

--- a/zip.js
+++ b/zip.js
@@ -2,6 +2,11 @@ const svc = require('@slingr/slingr-services');
 const fs = require('node:fs/promises');
 const AdmZip = require('adm-zip');
 
+/**
+ * Zips an array of files into a single zip file.
+ * @param {Array<{fileId: string, fileName: string}>} files - An array of objects, each containing a fileId and fileName.
+ * @returns {Promise<Buffer>} - A promise that resolves with the Buffer containing the zipped data.
+ */
 async function zipFiles(files) {
     const zip = new AdmZip();
     for (let { fileId, fileName } of files) {
@@ -11,18 +16,21 @@ async function zipFiles(files) {
     return zip.toBuffer();
 }
 
+/**
+ * Unzips a file and uploads the extracted files.
+ * @param {string} fileId - The ID of the zip file to unzip.
+ * @param {object} options - Options for unzipping, including password.
+ * @returns {Promise<Array<object>>} - A promise that resolves with an array of file objects.
+ */
 async function unzipFile(fileId, options = {}) {
     let data = await svc.files.download(fileId);
     let path = `/tmp/${fileId}`;
     await fs.writeFile(path, data);
     const zip = new AdmZip(path);
     let files = [];
-    const zipEntries = zip.getEntries(options.password);
+    const zipEntries = zip.getEntries(options.password)
+        .filter(entry => !entry.isDirectory); // ZIP Files are flat - Recursive is the default
     for (let zipEntry of zipEntries) {
-        if (zipEntry.isDirectory) {
-            if (! options.recursive) continue; // Ignore directories if is not recursive
-            // TODO: Implement recursive
-        }
         let file = await svc.files.upload(zipEntry.entryName, zipEntry.getData());
         files.push(file);
     }


### PR DESCRIPTION
- Recursive is the default since ZIP files are flat.

Solves issue #1 

I tested this code against a ZIP with multiple files nested in directories, and I got all the files inside all the subdirectories.

```js
const AdmZip = require('adm-zip');

let path = './test/test-recursive.zip';

(async () => {
    const zip = new AdmZip(path);
    const zipEntries = zip.getEntries();
    let count = 1;
    for (let zipEntry of zipEntries) {
        if (zipEntry.isDirectory) {
            continue;
        }
        console.log(count + ' - ' + zipEntry.entryName);
        count++;
    }
})();
```